### PR TITLE
publish all messages in persistent mode

### DIFF
--- a/include/metricq/source.hpp
+++ b/include/metricq/source.hpp
@@ -79,7 +79,6 @@ private:
     void config(const nlohmann::json& config);
 
 private:
-    std::string data_exchange_;
     std::unordered_map<std::string, Metric> metrics_;
 };
 } // namespace metricq

--- a/include/metricq/transformer.hpp
+++ b/include/metricq/transformer.hpp
@@ -60,7 +60,6 @@ private:
     void config(const nlohmann::json& config);
 
 private:
-    std::string data_exchange_;
     std::unordered_map<std::string, Metric> metrics_;
 };
 } // namespace metricq

--- a/python/metricq/agent.py
+++ b/python/metricq/agent.py
@@ -145,7 +145,8 @@ class Agent(RPCBase):
         msg = aio_pika.Message(body=body, correlation_id=correlation_id,
                                app_id=self.token,
                                reply_to=self._management_agent_queue.name,
-                               content_type='application/json')
+                               content_type='application/json',
+                               delivery_mode=aio_pika.DeliveryMode.PERSISTENT)
         self._rpc_response_handlers[correlation_id] = (response_callback, cleanup_on_response)
         await exchange.publish(msg, routing_key=routing_key)
 
@@ -181,7 +182,8 @@ class Agent(RPCBase):
                     aio_pika.Message(body=json.dumps(response).encode(),
                                      correlation_id=correlation_id,
                                      content_type='application/json',
-                                     app_id=self.token),
+                                     app_id=self.token,
+                                     delivery_mode=aio_pika.DeliveryMode.PERSISTENT),
                     routing_key=message.reply_to)
             else:
                 logger.debug('message is an RPC response')

--- a/python/metricq/source.py
+++ b/python/metricq/source.py
@@ -55,6 +55,9 @@ class Source(Client):
         self.data_channel = None
         self.data_exchange = None
 
+        # Maybe a subclass wants to change this some time
+        self.data_delivery_mode = aio_pika.DeliveryMode.PERSISTENT
+
         self.metrics = dict()
 
     async def connect(self):
@@ -122,5 +125,5 @@ class Source(Client):
         Actual send of a chunk,
         don't call from anywhere other than SourceMetric
         """
-        msg = aio_pika.Message(datachunk.SerializeToString())
+        msg = aio_pika.Message(datachunk.SerializeToString(), delivery_mode=self.data_delivery_mode)
         await self.data_exchange.publish(msg, routing_key=id)

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -150,6 +150,7 @@ void Connection::rpc(const std::string& function, ManagementResponseCallback res
     assert(!management_client_queue_.empty());
     envelope.setReplyTo(management_client_queue_);
     envelope.setContentType("application/json");
+    envelope.setPersistent(true);
 
     auto ret =
         management_rpc_response_callbacks_.emplace(correlation_id, std::move(response_callback));
@@ -206,6 +207,7 @@ void Connection::handle_management_message(const AMQP::Message& incoming_message
 
             log::debug("sending reply '{}' to {} / {}", reply_message, incoming_message.replyTo(),
                        incoming_message.correlationID());
+            envelope.setPersistent(true);
             management_channel_->publish("", incoming_message.replyTo(), envelope);
         }
         else

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -57,7 +57,7 @@ void Db::on_history(const AMQP::Message &incoming_message)
     std::string reply_message = response.SerializeAsString();
     AMQP::Envelope envelope(reply_message.data(), reply_message.size());
     envelope.setCorrelationID(incoming_message.correlationID());
-    envelope.setContentType("application/json");
+    envelope.setPersistent(true);
 
     data_channel_->publish("", incoming_message.replyTo(), envelope);
 }

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -56,13 +56,13 @@ void Source::on_connected()
 
 void Source::send(const std::string& id, const DataChunk& dc)
 {
-    data_channel_->publish(data_exchange_, id, dc.SerializeAsString());
+    data_publish(id, dc);
 }
 
 void Source::send(const std::string& id, TimeValue tv)
 {
     // TODO evaluate optimization of string construction
-    data_channel_->publish(data_exchange_, id, DataChunk(tv).SerializeAsString());
+    data_publish(id, DataChunk(tv));
 }
 
 void Source::config(const json& config)

--- a/src/transformer.cpp
+++ b/src/transformer.cpp
@@ -43,13 +43,13 @@ void Transformer::on_connected()
 
 void Transformer::send(const std::string& id, const DataChunk& dc)
 {
-    data_channel_->publish(data_exchange_, id, dc.SerializeAsString());
+    data_publish(id, dc);
 }
 
 void Transformer::send(const std::string& id, TimeValue tv)
 {
     // TODO evaluate optimization of string construction
-    data_channel_->publish(data_exchange_, id, DataChunk(tv).SerializeAsString());
+    data_publish(id, DataChunk(tv));
 }
 
 void Transformer::config(const json& config)


### PR DESCRIPTION
Is this a good idea?

Not loosing messages in the queues on rabbitmq restart is nice.

How would that affect performance?
Do we want this for rpc?
Do we want this for data messages?

Is there a different way to ensure messages are not lost at a *clean* reboot?