### PR TITLE
Fix cpp management queue names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,18 @@ matrix:
             - libssl-dev
           sources: *sources
     - os: linux
+      env: CXX="g++-9" CC="gcc-9"
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - gcc-9
+            - g++-9
+            - cmake
+            - cmake-data
+            - libssl-dev
+          sources: *sources
+    - os: linux
       env: CXX="clang++-5.0" CC="clang-5.0"
       compiler: clang
       addons:

--- a/include/metricq/exception.hpp
+++ b/include/metricq/exception.hpp
@@ -46,4 +46,4 @@ public:
     using Exception::Exception;
 };
 
-}
+} // namespace metricq

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -94,7 +94,7 @@ void Connection::connect(const std::string& server_address)
     management_channel_->onReady(debug_success_cb("management channel ready"));
     management_channel_->onError(debug_error_cb("management channel error"));
 
-    management_client_queue_ = std::string("client-") + connection_token_ + "-rpc";
+    management_client_queue_ = connection_token_ + "-rpc";
 
     management_channel_->declareQueue(management_client_queue_, AMQP::exclusive)
         .onSuccess([this](const std::string& name, [[maybe_unused]] int msgcount,


### PR DESCRIPTION
Fixes #33. 47da03c is the interesting commit.

This builds on top of #34, so either merge that first or rebase-merge.