### PR TITLE
Robust Agents: make Agents survive reconnects

### DIFF
--- a/python/metricq/client.py
+++ b/python/metricq/client.py
@@ -31,12 +31,16 @@
 from datetime import datetime
 from typing import Optional, Sequence, Union
 
-from .agent import Agent
+from .agent import Agent, RpcRequestError
 from .logging import get_logger
 from .rpc import rpc_handler
 from .types import Timedelta, Timestamp
 
 logger = get_logger(__name__)
+
+
+class ManagementRpcPublishError(RpcRequestError):
+    pass
 
 
 class Client(Agent):
@@ -66,13 +70,20 @@ class Client(Agent):
         await self.rpc_consume()
 
     async def rpc(self, function, **kwargs):
-        return await super().rpc(
-            function=function,
-            exchange=self._management_exchange,
-            routing_key=function,
-            cleanup_on_response=True,
-            **kwargs,
-        )
+        logger.debug("Waiting for management connection to be reestablished...")
+        await self._management_connection_watchdog.established()
+        try:
+            return await super().rpc(
+                function=function,
+                exchange=self._management_exchange,
+                routing_key=function,
+                cleanup_on_response=True,
+                **kwargs,
+            )
+        except RpcRequestError as e:
+            raise ManagementRpcPublishError(
+                f"Failed to send management RPC request {function!r}"
+            ) from e
 
     @rpc_handler("discover")
     async def _on_discover(self, **kwargs):

--- a/python/metricq/connection_watchdog.py
+++ b/python/metricq/connection_watchdog.py
@@ -1,0 +1,109 @@
+from asyncio import Task, Event, wait_for, create_task, CancelledError, TimeoutError
+from typing import Optional, Union, Callable
+
+from .logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class ConnectionWatchdog:
+    def __init__(
+        self,
+        on_timeout_callback: Callable[["ConnectionWatchdog"], None],
+        timeout: Union[int, float] = 60,
+        connection_name: str = "connection",
+    ):
+        """Watch a connection, fire a callback if it failed to reconnect before
+        the given timeout.
+
+        This class wraps a watchdog task that asynchronously waits for
+        established/closed events.  Use :py:meth:`start` to start the
+        connection watchdog.
+
+        :param on_timeout_callback:
+            Function called when the connection failed to reconnect before the
+            timeout occurs.
+        :param timeout: Union[int, float]
+            Time duration given until the connection is considered to have
+            failed to reconnect.  Use :py:meth:`set_established` to signal
+            reconnection.
+        :param connection_name: str
+            Human readable name of the connection, used in log messages.
+        """
+        self.connection_name = connection_name
+        self.timeout = timeout
+
+        self._callback = on_timeout_callback
+        self._closed_event = Event()
+        self._established_event = Event()
+        self._watchdog_task: Optional[Task] = None
+
+    def start(self):
+        """Start the connection watchdog task.
+
+        A call to this method will have no effect if the task is already
+        running.
+        """
+        if self._watchdog_task:
+            logger.warning(
+                f"ConnectionWatchdog for {self.connection_name} already started"
+            )
+            return
+
+        async def watchdog():
+            logger.debug("Started {} watchdog", self.connection_name)
+            try:
+                cap_connection_name = self.connection_name.capitalize()
+                while True:
+                    try:
+                        await wait_for(
+                            self._established_event.wait(), timeout=self.timeout
+                        )
+                        logger.debug("{} established", cap_connection_name)
+                    except TimeoutError:
+                        logger.warning(
+                            "{} failed to reconnect after {} seconds",
+                            cap_connection_name,
+                            self.timeout,
+                        )
+                        self._callback(self)
+                        break
+
+                    await self._closed_event.wait()
+                    logger.debug("{} was closed", cap_connection_name)
+
+            except CancelledError:
+                logger.debug("Cancelled {} watchdog", self.connection_name)
+                return
+
+        self._watchdog_task = create_task(watchdog())
+
+    def set_established(self):
+        """Signal that the connection has been established.
+        """
+        self._closed_event.clear()
+        self._established_event.set()
+
+    def set_closed(self):
+        """Signal that the connection has been closed.
+        """
+        self._established_event.clear()
+        self._closed_event.set()
+
+    async def closed(self):
+        """Asynchronously wait for the connection to be closed.
+        """
+        await self._closed_event.wait()
+
+    async def established(self):
+        """Asynchronously wait for the connection to be established.
+        """
+        await self._established_event.wait()
+
+    async def stop(self):
+        """Stop the connection watchdog task if it is running.
+        """
+        if self._watchdog_task:
+            self._watchdog_task.cancel()
+            await self._watchdog_task
+            self._watchdog_task = None

--- a/python/metricq/data_client.py
+++ b/python/metricq/data_client.py
@@ -26,10 +26,14 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from typing import Optional
+
 from yarl import URL
 
+from .agent import ReconnectTimeoutError
 from .client import Client
 from .logging import get_logger
+from .connection_watchdog import ConnectionWatchdog
 
 logger = get_logger(__name__)
 
@@ -42,6 +46,15 @@ class DataClient(Client):
         self.data_connection = None
         self.data_channel = None
         self.data_exchange = None
+        self._data_connection_watchdog = ConnectionWatchdog(
+            on_timeout_callback=lambda watchdog: self._schedule_stop(
+                ReconnectTimeoutError(
+                    f"Failed to reestablish {watchdog.connection_name} after {watchdog.timeout} seconds"
+                )
+            ),
+            timeout=kwargs.get("connection_timeout", 60),
+            connection_name="data connection",
+        )
 
     async def data_config(self, dataServerAddress, **kwargs):
         """
@@ -66,6 +79,12 @@ class DataClient(Client):
             )
             self.data_server_address = dataServerAddress
             self.data_connection = await self.make_connection(self.data_server_address)
+
+            self.data_connection.add_close_callback(self._on_data_connection_close)
+            self.data_connection.add_reconnect_callback(
+                self._on_data_connection_reconnect
+            )
+
             # publisher confirms seem to be buggy, disable for now
             self.data_channel = await self.data_connection.channel(
                 publisher_confirms=False
@@ -73,13 +92,23 @@ class DataClient(Client):
             # TODO configurable prefetch count
             await self.data_channel.set_qos(prefetch_count=400)
 
-    async def stop(self):
+            self._data_connection_watchdog.start()
+            self._data_connection_watchdog.set_established()
+
+    async def stop(self, exception: Optional[Exception]):
         logger.info("closing data channel and connection.")
+        await self._data_connection_watchdog.stop()
         if self.data_channel:
             await self.data_channel.close()
             self.data_channel = None
         if self.data_connection:
-            await self.data_connection.close()
+            await self.data_connection.close(exception)
             self.data_connection = None
         self.data_exchange = None
-        await super().stop()
+        await super().stop(exception)
+
+    def _on_data_connection_close(self, _exception: Optional[Exception]):
+        self._data_connection_watchdog.set_closed()
+
+    def _on_data_connection_reconnect(self, _connection):
+        self._data_connection_watchdog.set_established()

--- a/python/metricq/history_client.py
+++ b/python/metricq/history_client.py
@@ -30,6 +30,7 @@ import asyncio
 import uuid
 from collections import namedtuple
 from enum import Enum
+from typing import Optional
 
 import aio_pika
 
@@ -225,16 +226,16 @@ class HistoryClient(Client):
 
         await self._history_consume()
 
-    async def stop(self, reason=None):
+    async def stop(self, exception: Optional[Exception]):
         logger.info("closing history channel and connection.")
         if self.history_channel:
             await self.history_channel.close()
             self.history_channel = None
         if self.history_connection:
-            await self.history_connection.close()
+            await self.history_connection.close(exception)
             self.history_connection = None
         self.history_exchange = None
-        await super().stop()
+        await super().stop(exception)
 
     async def history_data_request(
         self,

--- a/python/metricq/interval_source.py
+++ b/python/metricq/interval_source.py
@@ -28,6 +28,7 @@
 
 import asyncio
 from abc import abstractmethod
+from typing import Optional
 
 from .logging import get_logger
 from .source import Source
@@ -43,10 +44,10 @@ class IntervalSource(Source):
         """
         super().__init__(*args, **kwargs)
         self.period = period
-        self._stop_future = None
+        self._interval_task_stop_future = None
 
     async def task(self):
-        self._stop_future = asyncio.Future()
+        self._interval_task_stop_future = self.event_loop.create_future()
         deadline = Timestamp.now()
         while True:
             await self.update()
@@ -63,20 +64,20 @@ class IntervalSource(Source):
 
                 timeout = (deadline - now).s
                 await asyncio.wait_for(
-                    asyncio.shield(self._stop_future), timeout=timeout
+                    asyncio.shield(self._interval_task_stop_future), timeout=timeout
                 )
-                self._stop_future.result()
+                self._interval_task_stop_future.result()
                 logger.info("stopping IntervalSource task")
                 break
             except asyncio.TimeoutError:
                 # This is the normal case, just continue with the loop
                 continue
 
-    async def stop(self):
+    async def stop(self, exception: Optional[Exception]):
         logger.debug("stop()")
-        if self._stop_future is not None:
-            self._stop_future.set_result(42)
-        await super().stop()
+        if self._interval_task_stop_future is not None:
+            self._interval_task_stop_future.set_result(None)
+        await super().stop(exception)
 
     @abstractmethod
     async def update(self):

--- a/python/metricq/sink.py
+++ b/python/metricq/sink.py
@@ -27,8 +27,12 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from abc import abstractmethod
+from asyncio import Task, CancelledError
+from typing import Set, Optional
 
 import aio_pika
+from aio_pika.queue import Queue
+from aiormq import ChannelInvalidStateError
 
 from .data_client import DataClient
 from .datachunk_pb2 import DataChunk
@@ -38,31 +42,106 @@ from .types import Timestamp
 logger = get_logger(__name__)
 
 
+class SinkError(Exception):
+    pass
+
+
+class SinkResubscribeError(SinkError):
+    pass
+
+
 class Sink(DataClient):
     def __init__(self, *args, add_uuid=True, **kwargs):
         super().__init__(*args, add_uuid=add_uuid, **kwargs)
-        self._data_queue = None
+
+        self._data_queue: Optional[Queue] = None
+        self._data_consumer_tag: Optional[str] = None
+        self._subscribed_metrics: Set[str] = set()
+        self._subscribe_args: dict = dict()
+        self._resubscribe_task: Optional[Task] = None
+
+    async def _declare_data_queue(self, name: str):
+        self._data_queue = await self.data_channel.declare_queue(
+            name=name, robust=False, passive=True
+        )
 
     async def sink_config(self, dataQueue, **kwargs):
         await self.data_config(**kwargs)
-        self._data_queue = await self.data_channel.declare_queue(
-            name=dataQueue, passive=True
-        )
+        await self._declare_data_queue(dataQueue)
+
         logger.info("starting sink consume")
-        await self._data_queue.consume(self._on_data_message)
+        self._data_consumer_tag = await self._data_queue.consume(self._on_data_message)
+
+    def _on_data_connection_reconnect(self, connection):
+        logger.info("Sink data connection ({}) reestablished!", connection)
+
+        if self._resubscribe_task is not None and not self._resubscribe_task.done():
+            logger.warning(
+                "Sink data connection was reestablished, but another resubscribe task is still running!"
+            )
+            self._resubscribe_task.cancel()
+
+        self._resubscribe_task = self.event_loop.create_task(
+            self._resubscribe(connection)
+        )
+
+        def resubscribe_done(task: Task):
+            try:
+                exception = task.exception()
+                if exception is None:
+                    self._data_connection_watchdog.set_established()
+                else:
+                    errmsg = "Resubscription failed with an unhandled exception"
+                    logger.error(
+                        "{}: {}", errmsg, exception,
+                    )
+                    raise SinkResubscribeError(errmsg) from exception
+            except CancelledError:
+                logger.warning("Resubscribe task was cancelled!")
+
+        self._resubscribe_task.add_done_callback(resubscribe_done)
+
+    async def _resubscribe(self, connection):
+        # Reuse manager-assigned data queue name for resubscription.
+        self._subscribe_args.update(dataQueue=self._data_queue.name)
+
+        metrics = tuple(self._subscribed_metrics)
+        logger.info(
+            "Resubscribing to {} metric(s) with RPC parameters {}...",
+            len(metrics),
+            self._subscribe_args,
+        )
+        response = await self.rpc(
+            "sink.subscribe", metrics=metrics, **self._subscribe_args,
+        )
+        await self._declare_data_queue(response["dataQueue"])
+
+        logger.debug("Restarting consume...")
+        await self._data_queue.consume(
+            self._on_data_message, consumer_tag=self._data_consumer_tag
+        )
 
     async def subscribe(self, metrics, **kwargs):
-        """
+        """Subscribe to a list of metrics.
+
         :param metrics:
-        :param expires: (optional) queue expiration time in seconds
+            names of the metrics to subscribe to
+        :param expires:
+            (optional) queue expiration time in seconds
+        :param metadata: bool
+            whether to return metric metadata in the response
         :return: rpc response
         """
         if self._data_queue is not None:
             kwargs["dataQueue"] = self._data_queue.name
         response = await self.rpc("sink.subscribe", metrics=metrics, **kwargs)
+
+        self._subscribed_metrics.update(metrics)
+        # Save the subscription RPC args in case we need to resubscribe (after a reconnect).
+        self._subscribe_args = kwargs
+
         if self._data_queue is None:
             await self.sink_config(**response)
-        assert self._data_queue.name == response["dataQueue"]
         return response
 
     async def unsubscribe(self, metrics):
@@ -70,6 +149,13 @@ class Sink(DataClient):
         await self.rpc(
             "sink.unsubscribe", dataQueue=self._data_queue.name, metrics=metrics
         )
+
+        self._subscribed_metrics.difference_update(metrics)
+
+        # If we just unsubscribed from all metrics, reset the subscription args
+        # to their defaults.
+        if not self._subscribed_metrics:
+            self._subscribe_args = dict()
 
     async def _on_data_message(self, message: aio_pika.IncomingMessage):
         with message.process(requeue=True):

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ class ProtoDevelop(develop):
 
 setup(
     name="metricq",
-    version="1.0.0",
+    version="1.1.0",
     author="TU Dresden",
     description="A highly-scalable, distributed metric data processing framework based on RabbitMQ",
     url="https://github.com/metricq/metricq",
@@ -74,7 +74,12 @@ setup(
     python_requires=">=3.5",
     packages=["metricq", "metricq_proto"],
     scripts=[],
-    install_requires=["aio-pika>=5.2.3", "protobuf>=3", "yarl"],
+    install_requires=[
+        "aio-pika~=6.0,>=6.4.0",
+        "aiormq~=3.0",  # TODO: remove once aio-pika reexports ChannelInvalidStateError
+        "protobuf>=3",
+        "yarl",
+    ],
     extras_require={
         "examples": ["aiomonitor", "click", "click-log", "click-completion"]
     },


### PR DESCRIPTION
This is basically #44 plus a strategy to make `Agent`s more robust:

* 518b4d9: `Agent`s will no longer publish on closed connections
* d51d638: `Sink`s will resubscribe to all their metrics after a successful reconnect
* a49fb9e: `Agent`s will give up trying to reconnect after a timeout (default 60s). We accidentally made them *too* robust.

Read the commit messages for more details what changed and why.