### PR TITLE
Move parts of metricq-manager to new management baseclass

### DIFF
--- a/docker-compose-development.yml
+++ b/docker-compose-development.yml
@@ -28,6 +28,20 @@ services:
     networks:
       - metricq-network
 
+  metricq-db-hta:
+    build:
+      context: https://github.com/metricq/metricq-db-hta.git
+    image: metricq-db-hta
+    environment:
+      token: metricq-db-hta
+      metricq_url: "amqp://admin:admin@rabbitmq-server/"
+      wait_for_rabbitmq_url: "rabbitmq-server:5672"
+    depends_on:
+      - rabbitmq-server
+      - metricq-manager
+    networks:
+      - metricq-network
+
   metricq-wizard-frontend:
     build:
       context: https://github.com/metricq/metricq-wizard-frontend.git

--- a/python/metricq/__init__.py
+++ b/python/metricq/__init__.py
@@ -33,6 +33,7 @@ from .data_client import DataClient
 from .history_client import HistoryClient
 from .interval_source import IntervalSource
 from .logging import get_logger
+from .management_agent import ManagementAgent
 from .rpc import rpc_handler
 from .sink import DurableSink, Sink
 from .source import Source

--- a/python/metricq/management_agent.py
+++ b/python/metricq/management_agent.py
@@ -1,5 +1,7 @@
+from itertools import islice
+
 import aio_pika
-from aiocouch import CouchDB
+from aiocouch import CouchDB, database
 
 from .agent import Agent
 from .logging import get_logger
@@ -11,18 +13,24 @@ logger = get_logger(__name__)
 
 class ManagementAgent(Agent):
     def __init__(
-        self, token, management_url, couchdb_url, couchdb_user, couchdb_password
+        self,
+        token,
+        management_url,
+        couchdb_url,
+        couchdb_user,
+        couchdb_password,
+        event_loop=None,
     ):
-        super().__init__(token, management_url)
+        super().__init__(token, management_url, event_loop=event_loop)
 
-        self.couchdb_client = CouchDB(
+        self.couchdb_client: CouchDB = CouchDB(
             couchdb_url,
             user=couchdb_user,
             password=couchdb_password,
             loop=self.event_loop,
         )
-        self.couchdb_db_config = None
-        self.couchdb_db_metadata = None
+        self.couchdb_db_config: database.Database = None
+        self.couchdb_db_metadata: database.Database = None
 
     async def connect(self):
         # First, connect to couchdb
@@ -47,3 +55,100 @@ class ManagementAgent(Agent):
             type=aio_pika.ExchangeType.FANOUT,
             durable=True,
         )
+
+    async def get_metrics(
+        self,
+        format="array",
+        historic=None,
+        selector=None,
+        prefix=None,
+        infix=None,
+        limit=None,
+    ):
+        if format not in ("array", "object"):
+            raise AttributeError("unknown format requested: {}".format(format))
+
+        if infix is not None and prefix is not None:
+            raise AttributeError('cannot get_metrics with both "prefix" and "infix"')
+
+        selector_dict = dict()
+        if selector is not None:
+            if isinstance(selector, str):
+                selector_dict["_id"] = {"$regex": selector}
+            elif isinstance(selector, list):
+                if len(selector) < 1:
+                    raise ValueError("Empty selector list")
+                if len(selector) == 1:
+                    # That may possibly be faster.
+                    selector_dict["_id"] = selector[0]
+                else:
+                    selector_dict["_id"] = {"$in": selector}
+            else:
+                raise TypeError(
+                    "Invalid selector type: {}, supported: str, list", type(selector)
+                )
+        if historic is not None:
+            if not isinstance(historic, bool):
+                raise AttributeError(
+                    'invalid type for "historic" argument: should be bool, is {}'.format(
+                        type(historic)
+                    )
+                )
+
+        # TODO can this be unified without compromising performance?
+        # Does this even perform well?
+        # ALSO: Async :-[
+        if selector_dict:
+            if historic is not None:
+                selector_dict["historic"] = historic
+            if prefix is not None or infix is not None:
+                raise AttributeError(
+                    'cannot get_metrics with both "selector" and "prefix" or "infix".'
+                )
+            aiter = self.couchdb_db_metadata.find(selector_dict, limit=limit)
+            if format == "array":
+                metrics = [doc["_id"] async for doc in aiter]
+            elif format == "object":
+                metrics = {doc["_id"]: doc.data async for doc in aiter}
+
+        else:  # No selector dict, all *fix / historic filtering
+            request_limit = limit
+            if infix is None:
+                request_prefix = prefix
+                if historic is not None:
+                    endpoint = self.couchdb_db_metadata.view("index", "historic")
+                else:
+                    endpoint = self.couchdb_db_metadata.all_docs
+            else:
+                request_prefix = infix
+                # These views produce stupid duplicates thus we must filter ourselves and request more
+                # to get enough results. We assume for no more than 6 infix segments on average
+                if limit is not None:
+                    request_limit = 6 * limit
+                if historic is not None:
+                    endpoint = self.couchdb_db_metadata.view("components", "historic")
+                else:
+                    raise NotImplementedError(
+                        "non-historic infix lookup not yet supported"
+                    )
+            if format == "array":
+                metrics = [
+                    key
+                    async for key in endpoint.ids(
+                        prefix=request_prefix, limit=request_limit
+                    )
+                ]
+                if request_limit != limit:
+                    # Object of type islice is not JSON serializable m(
+                    metrics = list(islice(sorted(set(metrics)), limit))
+            elif format == "object":
+                metrics = {
+                    doc["_id"]: doc.data
+                    async for doc in endpoint.docs(
+                        prefix=request_prefix, limit=request_limit
+                    )
+                }
+                if request_limit != limit:
+                    metrics = dict(islice(sorted(metrics.items()), limit))
+
+        return metrics

--- a/python/metricq/management_agent.py
+++ b/python/metricq/management_agent.py
@@ -106,12 +106,16 @@ class ManagementAgent(Agent):
         prefix=None,
         infix=None,
         limit=None,
+        source=None,
     ):
         if format not in ("array", "object"):
             raise AttributeError("unknown format requested: {}".format(format))
 
         if infix is not None and prefix is not None:
             raise AttributeError('cannot get_metrics with both "prefix" and "infix"')
+
+        if source is not None and historic is not None:
+            raise AttributeError('cannot get_metrics with both "historic" and "source"')
 
         selector_dict = dict()
         if selector is not None:
@@ -159,6 +163,9 @@ class ManagementAgent(Agent):
                 request_prefix = prefix
                 if historic is not None:
                     endpoint = self.couchdb_db_metadata.view("index", "historic")
+                elif source is not None:
+                    endpoint = self.couchdb_db_metadata.view("index", "source")
+                    request_prefix = source
                 else:
                     endpoint = self.couchdb_db_metadata.all_docs
             else:

--- a/python/metricq/management_agent.py
+++ b/python/metricq/management_agent.py
@@ -159,13 +159,15 @@ class ManagementAgent(Agent):
 
         else:  # No selector dict, all *fix / historic filtering
             request_limit = limit
+            request_params = {}
             if infix is None:
                 request_prefix = prefix
                 if historic is not None:
                     endpoint = self.couchdb_db_metadata.view("index", "historic")
                 elif source is not None:
                     endpoint = self.couchdb_db_metadata.view("index", "source")
-                    request_prefix = source
+                    request_prefix = None
+                    request_params["key"] = f'"{source}"'
                 else:
                     endpoint = self.couchdb_db_metadata.all_docs
             else:
@@ -194,7 +196,7 @@ class ManagementAgent(Agent):
                 metrics = {
                     doc["_id"]: doc.data
                     async for doc in endpoint.docs(
-                        prefix=request_prefix, limit=request_limit
+                        prefix=request_prefix, limit=request_limit, **request_params
                     )
                 }
                 if request_limit != limit:

--- a/python/metricq/management_agent.py
+++ b/python/metricq/management_agent.py
@@ -1,0 +1,49 @@
+import aio_pika
+from aiocouch import CouchDB
+
+from .agent import Agent
+from .logging import get_logger
+from .rpc import rpc_handler
+from .types import Timedelta, Timestamp
+
+logger = get_logger(__name__)
+
+
+class ManagementAgent(Agent):
+    def __init__(
+        self, token, management_url, couchdb_url, couchdb_user, couchdb_password
+    ):
+        super().__init__(token, management_url)
+
+        self.couchdb_client = CouchDB(
+            couchdb_url,
+            user=couchdb_user,
+            password=couchdb_password,
+            loop=self.event_loop,
+        )
+        self.couchdb_db_config = None
+        self.couchdb_db_metadata = None
+
+    async def connect(self):
+        # First, connect to couchdb
+        self.couchdb_db_config = await self.couchdb_client.create(
+            "config", exists_ok=True
+        )
+        self.couchdb_db_metadata = await self.couchdb_client.create(
+            "metadata", exists_ok=True
+        )
+
+        # After that, we do the MetricQ connection stuff
+        await super().connect()
+
+        logger.info("creating rpc exchanges")
+        self._management_exchange = await self._management_channel.declare_exchange(
+            name=self._management_exchange_name,
+            type=aio_pika.ExchangeType.TOPIC,
+            durable=True,
+        )
+        self._management_broadcast_exchange = await self._management_channel.declare_exchange(
+            name=self._management_broadcast_exchange_name,
+            type=aio_pika.ExchangeType.FANOUT,
+            durable=True,
+        )

--- a/python/metricq/management_agent.py
+++ b/python/metricq/management_agent.py
@@ -1,3 +1,33 @@
+# Copyright (c) 2019, ZIH,
+# Technische Universitaet Dresden,
+# Federal Republic of Germany
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright notice,
+#       this list of conditions and the following disclaimer in the documentation
+#       and/or other materials provided with the distribution.
+#     * Neither the name of metricq nor the names of its contributors
+#       may be used to endorse or promote products derived from this software
+#       without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 from itertools import islice
 
 import aio_pika


### PR DESCRIPTION
Moves parts of `metricq-manager` to a new management baseclass `ManagementAgent` for use in `metricq-manager` and `metricq-wizard`. Currently supports:

* CouchDB connection
* management and broadcast exchange setup
* reading config from db or file
* getting metrics from db