### PR TITLE
Cleanup shutdown

### DIFF
--- a/python/metricq/agent.py
+++ b/python/metricq/agent.py
@@ -203,8 +203,8 @@ class Agent(RPCDispatcher):
             "{}-rpc".format(self.token), exclusive=True
         )
 
+        self._management_connection_watchdog.start(loop=self.event_loop)
         self._management_connection_watchdog.set_established()
-        self._management_connection_watchdog.start()
 
     def run(
         self, catch_signals=("SIGINT", "SIGTERM"), cancel_on_exception=False

--- a/python/metricq/agent.py
+++ b/python/metricq/agent.py
@@ -587,6 +587,9 @@ class Agent(RPCDispatcher):
         logger.info("Reconnected to {}", connection)
 
     def _on_close(self, exception):
+        if isinstance(exception, asyncio.CancelledError):
+            logger.debug("Connection closed regularly")
+            return
         logger.info(
             "Connection closed: {} ({})", exception, type(exception).__qualname__
         )

--- a/python/metricq/agent.py
+++ b/python/metricq/agent.py
@@ -412,11 +412,6 @@ class Agent(RPCDispatcher):
 
         ex: Optional[Exception] = context.get("exception")
         if ex is not None:
-            logger.critical(
-                f"Agent {type(self).__qualname__} encountered an unhandled exception",
-                exc_info=(ex.__class__, ex, ex.__traceback__),
-            )
-
             is_keyboard_interrupt = isinstance(ex, KeyboardInterrupt)
             if self._cancel_on_exception or is_keyboard_interrupt:
                 if not is_keyboard_interrupt:
@@ -425,6 +420,11 @@ class Agent(RPCDispatcher):
                         type(ex).__qualname__,
                     )
                 self._schedule_stop(exception=ex, loop=loop)
+            else:
+                logger.error(
+                    f"Agent {type(self).__qualname__} encountered an unhandled exception",
+                    exc_info=(ex.__class__, ex, ex.__traceback__),
+                )
 
     def _schedule_stop(
         self,

--- a/python/metricq/connection_watchdog.py
+++ b/python/metricq/connection_watchdog.py
@@ -1,4 +1,4 @@
-from asyncio import CancelledError, Event, Task, TimeoutError, create_task, wait_for
+from asyncio import CancelledError, Event, Task, TimeoutError, wait_for
 from typing import Callable, Optional, Union
 
 from .logging import get_logger

--- a/python/metricq/connection_watchdog.py
+++ b/python/metricq/connection_watchdog.py
@@ -96,12 +96,10 @@ class ConnectionWatchdog:
 
     def set_closed(self):
         """Signal that the connection has been closed.
+        Note: Can be called when the watchdog is already stopped, so we need to check here
         """
-        assert (
-            self._closed_event is not None
-            and self._established_event is not None
-            and self._watchdog_task is not None
-        ), "attempting to operate with a watchdog that is not yet started"
+        if self._closed_event is None:
+            return
         self._established_event.clear()
         self._closed_event.set()
 

--- a/python/metricq/data_client.py
+++ b/python/metricq/data_client.py
@@ -92,7 +92,7 @@ class DataClient(Client):
             # TODO configurable prefetch count
             await self.data_channel.set_qos(prefetch_count=400)
 
-            self._data_connection_watchdog.start()
+            self._data_connection_watchdog.start(loop=self.event_loop)
             self._data_connection_watchdog.set_established()
 
     async def stop(self, exception: Optional[Exception] = None):

--- a/python/metricq/data_client.py
+++ b/python/metricq/data_client.py
@@ -102,7 +102,8 @@ class DataClient(Client):
             await self.data_channel.close()
             self.data_channel = None
         if self.data_connection:
-            await self.data_connection.close(exception)
+            # We need not pass anything as exception to this close. It will only hurt.
+            await self.data_connection.close()
             self.data_connection = None
         self.data_exchange = None
         await super().stop(exception)

--- a/python/metricq/history_client.py
+++ b/python/metricq/history_client.py
@@ -232,7 +232,8 @@ class HistoryClient(Client):
             await self.history_channel.close()
             self.history_channel = None
         if self.history_connection:
-            await self.history_connection.close(exception)
+            # We need not pass anything as exception to this close. It will only hurt.
+            await self.history_connection.close()
             self.history_connection = None
         self.history_exchange = None
         await super().stop(exception)

--- a/python/metricq/synchronous_source.py
+++ b/python/metricq/synchronous_source.py
@@ -119,12 +119,13 @@ class SynchronousSource:
             if exception:
                 logger.error("[SynchronousSource] failed to send data {}", exception)
 
-    def stop(self):
+    def stop(self, timeout=60):
         logger.info("[SynchronousSource] stopping")
-        asyncio.run_coroutine_threadsafe(self._source.stop(), self._source.event_loop)
-        # We cannot wait for the future because stop never finishes completion as
-        # it kills the event loop before returning
-        # It's ok though because join will block until the event loop is done
+        f = asyncio.run_coroutine_threadsafe(self._source.stop(), self._source.event_loop)
+        exception = f.exception(timeout=timeout)
+        if exception:
+            logger.error("[SynchronousSource] stop call failed {}", exception)
+
         logger.debug("[SynchronousSource] underlying source stopped")
         self._thread.join()
         logger.info("[SynchronousSource] thread joined")


### PR DESCRIPTION
Particularly synchronous shutdown was not working because the watchdog events were assigned to the wrong loop (thread) during ctor.