### PR TITLE
Unify discover response format of C++ and python clients

### DIFF
--- a/python/metricq/client.py
+++ b/python/metricq/client.py
@@ -47,7 +47,7 @@ class Client(Agent):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.starting_time = datetime.now()
+        self.starting_time = Timestamp.now()
 
     @property
     def name(self):
@@ -88,11 +88,13 @@ class Client(Agent):
     @rpc_handler("discover")
     async def _on_discover(self, **kwargs):
         logger.info("responding to discover")
-        t = datetime.now()
+        now = Timestamp.now()
+        uptime: int = (now - self.starting_time).ns
         return {
             "alive": True,
-            "uptime": Timedelta.from_timedelta(t - self.starting_time).ns,
-            "time": Timestamp.from_datetime(t).posix_ns,
+            "currentTime": now.datetime.isoformat(),
+            "startingTime": self.starting_time.datetime.isoformat(),
+            "uptime": uptime,
         }
 
     async def get_metrics(

--- a/src/data_client.cpp
+++ b/src/data_client.cpp
@@ -39,13 +39,14 @@ namespace metricq
 {
 DataClient::DataClient(const std::string& token, bool add_uuid) : Connection(token, add_uuid)
 {
-    TimePoint starting_time = Clock::now();
-    register_management_callback("discover", [token, starting_time](const json&) {
-        json response;
-        response["alive"] = true;
-        response["currentTime"] = Clock::format_iso(Clock::now());
-        response["startingTime"] = Clock::format_iso(starting_time);
-        return response;
+    register_management_callback("discover", [starting_time = Clock::now()](const json&) -> json {
+        auto current_time = Clock::now();
+        auto uptime = (current_time - starting_time).count(); // current uptime in nanoseconds
+
+        return { { "alive", true },
+                 { "currentTime", Clock::format_iso(current_time) },
+                 { "startingTime", Clock::format_iso(starting_time) },
+                 { "uptime", uptime } };
     });
 }
 

--- a/src/history_client.cpp
+++ b/src/history_client.cpp
@@ -40,13 +40,14 @@ namespace metricq
 {
 HistoryClient::HistoryClient(const std::string& token, bool add_uuid) : Connection(token, add_uuid)
 {
-    TimePoint starting_time = Clock::now();
-    register_management_callback("discover", [token, starting_time](const json&) {
-        json response;
-        response["alive"] = true;
-        response["currentTime"] = Clock::format_iso(Clock::now());
-        response["startingTime"] = Clock::format_iso(starting_time);
-        return response;
+    register_management_callback("discover", [starting_time = Clock::now()](const json&) -> json {
+        auto current_time = Clock::now();
+        auto uptime = (current_time - starting_time).count(); // current uptime in nanoseconds
+
+        return { { "alive", true },
+                 { "currentTime", Clock::format_iso(current_time) },
+                 { "startingTime", Clock::format_iso(starting_time) },
+                 { "uptime", uptime } };
     });
 }
 


### PR DESCRIPTION
When receiving to a `discover` broadcast RPC, a client will now respond with a JSON object in the form of

```ts
    interface DiscverResponse {
        alive?: bool;
        currentTime?: Iso8601String;
        startingTime?: Iso8601String;
        uptime?: NanoSeconds;
    }
```

When receiving such a response, note that all fields are optional.
If `alive` is missing, assume the client is alive; if `uptime` is missing but both `currentTime` and `startingTime` are given, calculate `uptime` as the difference (in number of nanoseconds) between the latter two.

This fixes #55.